### PR TITLE
Adds unit test placeholders, linting and Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+---
+
+sudo: false
+
+language: python
+cache: pip
+
+before_script:
+  - pip install tox
+
+script: tox
+
+matrix:
+  include:
+
+    - python: "3.4"
+      env: TOXENV=py34
+
+    - python: "3.5"
+      env: TOXENV=py35
+
+    - python: "3.6"
+      env: TOXENV=py36
+
+    - python: "3.7"
+      env: TOXENV=py37
+
+    # Linters
+
+    - python: "3.7"
+      env: TOXENV=linting

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Add software operating systems, programming languages or libraries which are req
 
 *   Python 3.4 or higher
 *   [ArchivesSnake](https://github.com/archivesspace-labs/ArchivesSnake)
+*   [tox](https://tox.readthedocs.io/) (for running tests)
 
 ### Installation
 
@@ -32,6 +33,23 @@ Add software operating systems, programming languages or libraries which are req
 ### Usage
 
 *Write usage instructions, including configuration details, settings or arguments available.*
+
+#### Tests
+
+`rac_aspace` comes with unit tests as well as linting. The easiest way to make sure all tests pass is to run `tox` from the root of the repository. This will execute all tests, and will also run `autopep8` and `flake8` linters against the codebase.
+
+If you want to run a single unit test, you can also target a specific test file:
+
+```
+$ python tests/test_data_helpers.py
+```
+
+or you can run `autopep8` and `flake8` on their own:
+
+```
+$ autopep8 --in-place --aggressive -r .
+$ flake8
+```
 
 ### License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 ArchivesSnake==0.8.1
+boltons=20.0.0
+PyYAML==5.2.0
 tox==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ArchivesSnake==0.8.1
+tox==3.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ArchivesSnake==0.8.1
-tox==3.14.1
+tox==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ArchivesSnake==0.8.1
-boltons=20.0.0
+boltons==20.0.0
 PyYAML==5.2.0
 tox==3.14.0

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -1,0 +1,14 @@
+"""
+Unit tests for Data Helpers
+"""
+import unittest
+
+
+class TestDataHelpers(unittest.TestCase):
+
+    def test_helpers(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,14 @@
+"""
+Unit tests for delete operations in ArchivesSpace
+"""
+import unittest
+
+
+class TestDataDeleters(unittest.TestCase):
+
+    def test_data_deleters(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,14 @@
+"""
+Unit tests for write operations in ArchivesSpace
+"""
+import unittest
+
+
+class TestDataSavers(unittest.TestCase):
+
+    def test_data_savers(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,14 @@
+"""
+Unit tests for Serializers
+"""
+import unittest
+
+
+class TestSerializers(unittest.TestCase):
+
+    def test_serialization(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py34, py35, py36, py37, linting
+skipsdist = True
+
+[testenv]
+deps =
+  -rrequirements.txt
+  pytest
+skip_install = True
+commands = pytest
+
+[testenv:linting]
+basepython = python3
+deps =
+  autopep8
+  flake8
+  flake8-import-order
+commands =
+  autopep8 --exit-code --aggressive --diff -r .
+  flake8 {posargs}
+
+[flake8]
+application-import-names = flake8
+select = B, C, E, F, W, B, B950
+import-order-style = pep8
+max-complexity = 10


### PR DESCRIPTION
## Sets up the following:
- A `requirements.txt` file which lists all the dependencies necessary to build the library. See #8 for future work related to this file.
- Placeholder unit tests, located in the `tests/` directory. As functionality is added, tests should be added to these files. Ultimately we may want to combine these into a single file, but this will allow for fewer merge conflicts.
- A `tox` config file, which allows unit tests and linting (using `autopep8` and `flake8`) to be run using a single command, ie `tox`. For more on `tox`, see the [official docs](https://tox.readthedocs.io/en/latest/index.html).
- A Travis CI config file (`.travis.yml`) which runs unit tests and linting in Github each time a pull request is submitted (it is possible to configure Travis CI to run on each time code is pushed).

## Questions/discussion points:
- Unit tests are currently run on Python 3.4, 3.5, 3.6 and 3.7. Is it necessary to test on all of these versions?
- I think we need to find some ways to be explicit about our expectations around linting. I have some ideas, which I've documented in #9 and #7 but I'd be interested in hearing other ideas.

fixes #1 