### PR TITLE
Add git pre-commit hooks for linting, fixes #7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,4 @@ repos:
     rev: v1.5
     hooks:
     -   id: autopep8
+        args: [--exit-code, --aggressive, --diff, -r]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.5
+    hooks:
+    -   id: autopep8

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Add software operating systems, programming languages or libraries which are req
 *   Python 3.4 or higher
 *   [ArchivesSnake](https://github.com/archivesspace-labs/ArchivesSnake)
 *   [tox](https://tox.readthedocs.io/) (for running tests)
+*   [pre-commit](https://pre-commit.com/) (for running linters before committing)
+    *   After installing pre-commit, install the git-hook scripts:
+
+    ```
+    $ pre-commit install
+    ```
 
 ### Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ boltons==20.0.0
 fuzzywuzzy==0.17.0
 PyYAML==5.2.0
 tox==3.14.0
+pre-commit==2.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -11,23 +11,13 @@ commands = pytest
 
 [testenv:linting]
 basepython = python3
-deps =
-  autopep8
-  flake8
-  flake8-import-order
+skip_install = true
+deps = pre-commit
 commands =
-  autopep8 --exit-code --aggressive --diff -r .
-  flake8 {posargs}
+    pre-commit run --all-files --show-diff-on-failure
 
 [flake8]
 application-import-names = flake8
 select = B, C, E, F, W, B, B950
 import-order-style = pep8
 max-complexity = 10
-
-[testenv:pre-commit]
-basepython = python3
-skip_install = true
-deps = pre-commit
-commands =
-    pre-commit run --all-files --show-diff-on-failure

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,6 @@ deps =
 skip_install = True
 commands = pytest
 
-[testenv:pre-commit]
-basepython = python3
-skip_install = true
-deps = pre-commit
-commands =
-    pre-commit run --all-files --show-diff-on-failure
-
 [testenv:linting]
 basepython = python3
 deps =
@@ -31,3 +24,10 @@ application-import-names = flake8
 select = B, C, E, F, W, B, B950
 import-order-style = pep8
 max-complexity = 10
+
+[testenv:pre-commit]
+basepython = python3
+skip_install = true
+deps = pre-commit
+commands =
+    pre-commit run --all-files --show-diff-on-failure

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,13 @@ deps =
 skip_install = True
 commands = pytest
 
+[testenv:pre-commit]
+basepython = python3
+skip_install = true
+deps = pre-commit
+commands =
+    pre-commit run --all-files --show-diff-on-failure
+
 [testenv:linting]
 basepython = python3
 deps =


### PR DESCRIPTION
Fixes #7 

## Proposed Changes

  - Add `.pre-commit-config.yaml` with flake8 and autopep8 pre-commit hooks
  - Add pre-commit specs to `tox.ini` and `requirements.txt`
  - Update README requirements section to include pre-commit installation

## Notes

  - This is currently failing Travis-CI tests because `pre-commit 2.1.1` is not supported by Python versions below Python 3.6. This should be addressed with issue #8. 
