### PR TITLE
add exceptions to flake8 rules, fixes #26

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ basepython = python3
 deps =
   autopep8
   flake8
+  # checks that import statements are grouped and ordered in a consistent and PEP 8-compliant way
   flake8-import-order
 commands =
   autopep8 --exit-code --aggressive --diff -r .
@@ -21,6 +22,17 @@ commands =
 
 [flake8]
 application-import-names = flake8
-select = B, C, E, F, W, B, B950
+select = B, C, E, F, W, B950
 import-order-style = pep8
 max-complexity = 10
+ignore =
+	E501 # Line too long (82 > 79 characters). Linter enforemcent is not necessary, as longer lines can improve code quality
+	W391 # Blank line at end of file
+	# Other common exceptions to consider:
+		# E203 Ignores Whitespace before ':'
+		# E266 Too many leading '#' for block comment
+		# W503 Line break occurred before a binary operator, or W504 Line break occurred after a binary operator
+		# F403 'from module import *' used; unable to detect undefined names
+		# F401 Module imported but unused
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,5 @@ ignore =
 		# E266 Too many leading '#' for block comment
 		# W503 Line break occurred before a binary operator, or W504 Line break occurred after a binary operator
 		# F403 'from module import *' used; unable to detect undefined names
-		# F401 Module imported but unused
 
 


### PR DESCRIPTION
Fixes #26 

## Proposed Changes

  - Add flake8 exceptions for line length and blank line at end of file (E501, W391)
  - Remove duplicate error selector in autopep8 configs
  - Include code comments with common flake8 exceptions to consider adding as our work continues

## Notes
- Does not implement the `--in-place` argument autopep8, but that may be considered in the future
- This PR should be merged before PR #47 