### PR TITLE
Add docstrings and remove unnecessary text from README, fixes #39 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,42 +6,7 @@
 
 ### Data Helpers
 
-Target, extract, and modify structured data from ArchiveSpace to allow users to export, update, add, and delete data. Data helpers leverage the abstraction layer of ArchivesSnake to get and post changes back to a JSONModel object(s) either in bulk, or by specifying a unique identifier. Data helpers enable cleanup tasks, changes to conform to new organizational policies and procedures, and to validate against existing archival and institutional standards. Data helper functionality includes:
-
-#### Retrieve
-Get specific fields from a data object.
-
-- ~~Notes attached to archival objects or resources~~ see `of_type()` and `get_note_text()`
-- ~~Location data~~ see `get_locations()`
-- Container data
-- Date data
-- ~~Data fields within an AS object, including arrays within arrays~~ see conversation about list comprehension
-- ~~Unlinked agents, subjects, top containers, and digital objects~~ see `get_orphans()`
-
-#### Infer
-Return properties based on other data elements, either on the same object or another.
-
-- ~~Date expression based on date type and start/end dates~~ see `expression()`
-- ~~List of all the restricted archival objects associated with a given top container~~ see `text_in_note()` and `is_restricted()` and `indicates_restriction()`
-- see also `closest_value()`
-
-#### Extend relationships
-Find related objects which are not related via `ref` properties (and so cannot be traversed in the ASpace abstraction layer)
-
-- ~~Archival objects associated with a top container~~ see `associated_objects()` 
-
-#### Concatenate Fields
-Combine discrete data elements to form a single value.
-
-- ~~Container type plus identifier~~ see `format_container()`
-- ~~Four-part id (id_0 plus id_1 plus id_2 plus id_3)~~  see `format_resource_id()`
-- ~~Note content. Depending on note type, this requires iterating through subnotes.~~ see `get_note_text()`
-- see also `format_location()`
-
-#### Enable User Input
-
-- ~~To target specific objects and resources in order to retrieve or modify data~~ see `get_user_input()`
-- ~~For initial setup of local configurations~~ see `get_config()`
+`rac_aspace` provides data helpers which provide additional functionality on top of the abstraction layer of ArchivesSnake to retrieve, infer and concatenate data elements. They can also extend (or invert) relationships between different objects, such as locations and archival objects. Data helpers enable cleanup tasks, changes to conform to new organizational policies and procedures, and to validate against existing archival and institutional standards.
 
 ### Serialize
 

--- a/rac_aspace/data_helpers.py
+++ b/rac_aspace/data_helpers.py
@@ -37,21 +37,6 @@ def text_in_note(note, query_string):
     return (True if ratio > CONFIDENCE_RATIO else False)
 
 
-def of_type(list, desired_type):
-    """Returns objects in a list which match a specific jsonmodel_type."""
-    return [obj for obj in list if obj.jsonmodel_type == desired_type]
-
-
-def of_type_longer(list, desired_type):
-    """Move verbose version of `of_type` to demonstrate a more verbose
-    approach."""
-    objects = []
-    for obj in list:
-        if obj.jsonmodel_type == desired_type:
-            objects.append(obj)
-    return objects
-
-
 def get_locations(archival_object):
     """
     Returns a list of locations objects associated with an
@@ -164,23 +149,3 @@ def is_restricted(archival_object):
         if indicates_restriction(rights_statement):
             return True
     return False
-
-
-def get_user_input(prompt):
-    """
-    Allows users to input data.
-
-    This could be used like:
-    ```
-    variable = get_user_input("Please enter your name here:")
-    ```
-    """
-    print(prompt)
-    return raw_input()
-
-
-def get_config():
-    """Sets up configuration values necessary for ASpace."""
-    pass
-    # look for file
-    # look for env variables

--- a/rac_aspace/data_helpers.py
+++ b/rac_aspace/data_helpers.py
@@ -1,44 +1,82 @@
+"""Data Helpers
+
+Data helpers leverage the abstraction layer of ArchivesSnake to provide
+additional functionality for retrieving, inferring and concatenating data
+elements. They can also extend (or invert) relationships between different
+objects.
+
+"""
+
 from fuzzywuzzy import fuzz
 
 
 def get_note_text(note):
-    """Returns note content as a list."""
+    """Parses note content from different note types.
+
+    Args:
+        note (dict): an ArchivesSpace note object.
+
+    Returns:
+        list: a list containing note content.
+    """
     def parse_subnote(subnote):
-        """Returns content in subnotes"""
+        """Parses note content from subnotes.
+
+        Args:
+            subnote (dict): an ArchivesSpace subnote object.
+
+        Returns:
+            list: a list containing subnote content.
+        """
         if subnote.jsonmodel_type in [
                 'note_orderedlist', 'note_definedlist', 'note_index',
                 'note_chronology']:
-            return subnote.items
+            content = subnote.items
         elif subnote.jsonmodel_type == 'note_bibliography':
             data = []
             data.append(subnote.content)
             data.append(subnote.items)
-            return data
+            content = data
         else:
-            return subnote.content if isinstance(
+            content = subnote.content if isinstance(
                 subnote.content, list) else [subnote.content]
+        return content
 
     if note.jsonmodel_type == "note_singlepart":
-        return note.source.content.strip("]['").split(', ')
+        content = note.source.content.strip("]['").split(', ')
     elif note.jsonmodel_type == "note_index":
-        return note.source.items.strip("]['").split(', ')
+        content = note.source.items.strip("]['").split(', ')
     else:
-        return (parse_subnote(sn) for sn in note.subnotes)
+        content = (parse_subnote(sn) for sn in note.subnotes)
+    return content
 
 
 def text_in_note(note, query_string):
-    """Returns a boolean indicating whether a string was found in note text.
-    Uses fuzzy matching."""
+    """Performs fuzzy searching against note text.
+
+    Args:
+        note (dict): an ArchivesSpace note object.
+        query_string (str): a string to match against.
+
+    Returns:
+        bool: True if a match is found for `query_string`, False if no match is
+            found.
+    """
     CONFIDENCE_RATIO = 97
+    """int: Minimum confidence ratio to match against."""
     note_content = get_note_text(note)
     ratio = fuzz.token_sort_ratio(note_content.lower(), query_string.lower())
     return (True if ratio > CONFIDENCE_RATIO else False)
 
 
 def get_locations(archival_object):
-    """
-    Returns a list of locations objects associated with an
-    archival object.
+    """Finds locations associated with an archival object.
+
+    Args:
+        archival_object (dict): an ArchivesSpace archival_object.
+
+    Returns:
+        list: Locations objects associated with the archival object.
     """
     locations = []
     for instance in archival_object.instances:
@@ -47,7 +85,14 @@ def get_locations(archival_object):
 
 
 def format_location(location):
-    """Return a human-readable string for a location."""
+    """Generates a human-readable string describing a location.
+
+    Args:
+        location (dict): an ArchivesSpace location object.
+
+    Returns:
+        str: a string representing the location
+    """
     pass
 # QUESTION: pass a format string
 # QUESTION: is this a more generalizable function?
@@ -57,18 +102,28 @@ def format_location(location):
 
 
 def format_container(top_container):
-    """
-    Returns a human-readable concatenation of top container type
-    and indicator.
+    """Generates a human-readable string describing a container.
+
+    Args:
+        top_container (dict): an ArchivesSpace top_container object.
+
+    Returns:
+        str: a concatenation of top container type and indicator.
     """
     return "{0} {1}".format(top_container.container_type,
                             top_container.indicator)
 
 
 def format_resource_id(resource, separator=":"):
-    """
-    Returns the four-part ID for a resource record. Accepts an optional
-    separator argument, which is set to ":" by default
+    """Concatenates the four-part ID for a resource record.
+
+    Args:
+        resource (dict): an ArchivesSpace resource object.
+        separator (str): a separator to insert between the id parts. Defaults
+            to `:`.
+
+    Returns:
+        str: a concatenated four-part ID for the resource record.
     """
     resource_id = []
     for x in range(3):
@@ -80,9 +135,17 @@ def format_resource_id(resource, separator=":"):
 
 
 def closest_value(archival_object, key):
-    """
-    Returns the closest matching for a key, iterating up through an object's
-    ancestors until it finds a match.
+    """Finds the closest value matching a key.
+
+    Starts with an archival object, and iterates up through it's ancestors
+    until it finds a match for a key that is not empty or null.
+
+    Args:
+        archival_object (dict): an ArchivesSpace archival_object
+        key (str): the key to match against.
+
+    Returns:
+        The value of the key, which could be a str, list, or dict
     """
     if getattr(archival_object, key) not in ['', [], {}, None]:
         return archival_object.key
@@ -92,17 +155,31 @@ def closest_value(archival_object, key):
 
 
 def get_orphans(object_list, null_attribute):
-    """
-    Generator function which returns objects that do not have a value in a
-    specified field.
+    """Finds objects in a list which do not have a value in a specified field.
+
+    Args:
+        object_list (list): a list of ArchivesSpace objects.
+        null_attribute: an attribute which must be empty or null.
+
+    Yields:
+        dict: a list of ArchivesSpace objects.
     """
     for obj in object_list:
         if getattr(obj, null_attribute) in ['', [], {}, None]:
             yield obj
 
 
-def expression(date):
-    """Always returns a date expression for a date object."""
+def get_expression(date):
+    """Returns a date expression for a date object.
+
+    Concatenates start and end dates if no date expression exists.
+
+    Args:
+        date (dict): an ArchivesSpace date object.
+
+    Returns:
+        str: a date expression for the date object.
+    """
     if date.expression:
         return date.expression
     if date.date_end:
@@ -112,14 +189,27 @@ def expression(date):
 
 
 def associated_objects(top_container):
-    """Return all the archival objects associated with a top container."""
+    """Returns all archival objects associated with a top container.
+
+    Args:
+        top_container (dict): an ArchivesSpace top_container object.
+
+    Returns:
+        list: a list of associated archival objects.
+    """
     pass
 # probably have to do some SOLR stuff
 
 
 def indicates_restriction(rights_statement):
-    """Returns a boolean indicating whether or not a rights statement
-    indicates a current restriction."""
+    """Parses a rights statement to determine if it indicates a restriction.
+
+    Args:
+        rights_statement (dict): an ArchivesSpace rights statement.
+
+    Returns:
+        bool: True if rights statement indicates a restriction, False if not.
+    """
     # If rights_statement.date_end is before today:
     # return False
     # for rights_granted in rights_statement.rights_granted:
@@ -130,13 +220,18 @@ def indicates_restriction(rights_statement):
 
 
 def is_restricted(archival_object):
-    """
-    Return a boolean which indicates if an object is restricted.
+    """Parses an archival object to determine if it is restricted.
 
     Iterates through notes, looking for a conditions governing access note
     which contains a particular set of strings.
     Also looks for associated rights statements which indicate object may be
     restricted.
+
+    Args:
+        archival_object (dict): an ArchivesSpace archival_object.
+
+    Returns:
+        bool: True if archival object is restricted, False if not.
     """
     query_string = "materials are restricted"
     for note in archival_object.notes:

--- a/rac_aspace/data_helpers.py
+++ b/rac_aspace/data_helpers.py
@@ -1,5 +1,3 @@
-import raw_input
-
 from fuzzywuzzy import fuzz
 
 


### PR DESCRIPTION
Fixes #39 

## Proposed Changes

  - Adds docstrings in the Google format (see [Sphinx example](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) and [official docs](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for more on this format
  - Removes duplicative text from README.
  - Note that this is branched from #45 (because I didn't want to write docstrings for unnecessary functions), so that should be merged first.