### PR TITLE
Adds data helper to strip HTML tags

### DIFF
--- a/rac_aspace/data_helpers.py
+++ b/rac_aspace/data_helpers.py
@@ -1,4 +1,5 @@
 import raw_input
+import re
 
 from fuzzywuzzy import fuzz
 
@@ -184,3 +185,10 @@ def get_config():
     pass
     # look for file
     # look for env variables
+
+
+def strip_html_tags(string):
+    """Strips HTML tags from a string."""
+    tag_match = re.compile('<.*?>')
+    cleantext = re.sub(tag_match, '', string)
+    return cleantext

--- a/rac_aspace/data_helpers.py
+++ b/rac_aspace/data_helpers.py
@@ -6,7 +6,7 @@ elements. They can also extend (or invert) relationships between different
 objects.
 
 """
-
+import re
 from fuzzywuzzy import fuzz
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ boltons==20.0.0
 fuzzywuzzy==0.17.0
 PyYAML==5.2.0
 tox==3.14.0
-pre-commit==2.1.1
+pre-commit==1.18.3

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -3,11 +3,24 @@ Unit tests for Data Helpers
 """
 import unittest
 
+from rac_aspace import data_helpers
+
 
 class TestDataHelpers(unittest.TestCase):
 
     def test_helpers(self):
         pass
+
+    def test_strip_html_tags(self):
+        input = "<h1>Title</h1><p>This is <i>some</i> text! It is wrapped in a \
+                variety of html tags, which should <strong>all</strong> be \
+                stripped &amp; not returned.</p>"
+        expected = "TitleThis is some text! It is wrapped in a variety of html \
+                    tags, which should all be stripped &amp; not returned."
+        output = data_helpers.strip_html_tags(input)
+        self.assertEqual(
+            expected, output,
+            "Expected string {} but got {} instead.".format(expected, output))
 
 
 if __name__ == '__main__':

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -12,11 +12,8 @@ class TestDataHelpers(unittest.TestCase):
         pass
 
     def test_strip_html_tags(self):
-        input = "<h1>Title</h1><p>This is <i>some</i> text! It is wrapped in a \
-                variety of html tags, which should <strong>all</strong> be \
-                stripped &amp; not returned.</p>"
-        expected = "TitleThis is some text! It is wrapped in a variety of html \
-                    tags, which should all be stripped &amp; not returned."
+        input = "<h1>Title</h1><p>This is <i>some</i> text! It is wrapped in a variety of html tags, which should <strong>all</strong> be stripped &amp; not returned.</p>"
+        expected = "TitleThis is some text! It is wrapped in a variety of html tags, which should all be stripped &amp; not returned."
         output = data_helpers.strip_html_tags(input)
         self.assertEqual(
             expected, output,


### PR DESCRIPTION
## Changes
Adds `strip_html_tags` function which removes HTML tags from a string. A corresponding unit test has also been added.

## Questions
Are there edge cases I haven't considered here?

fixes #42 