### PR TITLE
Adds unit tests for serializers

### DIFF
--- a/rac_aspace/serializers.py
+++ b/rac_aspace/serializers.py
@@ -1,27 +1,37 @@
 import csv
 
 
-data = {}
-
-
 class Serializer:
 
     def __init__(self, filename, filemode="w"):
+        """Sets initial attributes for serializers.
+
+        Ensures that a filemode is provided which supports write operations, and
+        replaces the filename extension if it does not match the extension
+        specified by the class.
+
+        Args:
+            filename (str): a filename at which the data should be serialized.
+            filemode (str): Optional argument used when opening files.
         """
-        Currently this class expects to get the following parameters:
-        Filename: a filename including the file extension
-        Filemode: Optional argument set to work with already existing files.
-        """
+        if filemode.startswith("r"):
+            raise TypeError("Filemode must allow write operations.")
+        self.filemode = filemode
+        if filename.split(".")[-1] != self.extension:
+            if len(filename.split(".")) > 1:
+                filename = filename[:-len(filename.split(".")[-1])] + self.extension
+            else:
+                filename = "{}.{}".format(filename, self.extension)
         self.filename = filename
 
     def write_data(self, data):
+        """Writes data to a Serializer class.
+
+        Args:
+            data (dict or list): a sequence of dicts.
         """
-        This function writes the data passed to it to a csv or tsv.
-        Data: Data in a dictionary. Doesn't handle nested arrays.
-        """
-        data = data
-        fieldnames = list(data.keys())
-        with open(self.filename, 'w') as f:
+        fieldnames = list(data.keys() if isinstance(data, dict) else data[0].keys())
+        with open(self.filename, self.filemode) as f:
             writer = csv.DictWriter(
                 f, fieldnames=fieldnames, delimiter=self.delimiter)
             writer.writeheader()
@@ -29,10 +39,14 @@ class Serializer:
 
 
 class CSVWriter(Serializer):
+    """Writes data to a CSV file."""
 
-    delimiter = "','"
+    delimiter = ","
+    extension = "csv"
 
 
 class TSVWriter(Serializer):
+    """Writes data to a TSV file."""
 
-    delimiter = "'\t'"
+    delimiter = "\t"
+    extension = "tsv"

--- a/rac_aspace/serializers.py
+++ b/rac_aspace/serializers.py
@@ -18,8 +18,9 @@ class Serializer:
             raise TypeError("Filemode must allow write operations.")
         self.filemode = filemode
         if filename.split(".")[-1] != self.extension:
-            if len(filename.split(".")) > 1:
-                filename = filename[:-len(filename.split(".")[-1])] + self.extension
+            extension_len = len(filename.split(".")[-1])
+            if extension_len > 1:
+                filename = filename[:-extension_len] + self.extension
             else:
                 filename = "{}.{}".format(filename, self.extension)
         self.filename = filename
@@ -30,7 +31,9 @@ class Serializer:
         Args:
             data (dict or list): a sequence of dicts.
         """
-        fieldnames = list(data.keys() if isinstance(data, dict) else data[0].keys())
+        fieldnames = list(
+            data.keys() if isinstance(
+                data, dict) else data[0].keys())
         with open(self.filename, self.filemode) as f:
             writer = csv.DictWriter(
                 f, fieldnames=fieldnames, delimiter=self.delimiter)

--- a/rac_aspace/serializers.py
+++ b/rac_aspace/serializers.py
@@ -17,10 +17,10 @@ class Serializer:
         if filemode.startswith("r"):
             raise TypeError("Filemode must allow write operations.")
         self.filemode = filemode
-        if filename.split(".")[-1] != self.extension:
-            extension_len = len(filename.split(".")[-1])
-            if extension_len > 1:
-                filename = filename[:-extension_len] + self.extension
+        extension = filename.split(".")[-1]
+        if extension != self.extension:
+            if len(filename.split(".")) > 1:
+                filename = filename[:-len(extension)] + self.extension
             else:
                 filename = "{}.{}".format(filename, self.extension)
         self.filename = filename

--- a/rac_aspace/serializers.py
+++ b/rac_aspace/serializers.py
@@ -26,7 +26,7 @@ class Serializer:
         self.filename = filename
 
     def write_data(self, data):
-        """Writes data to a Serializer class.
+        """Writes data to a file.
 
         Args:
             data (dict or list): a sequence of dicts.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ boltons==20.0.0
 fuzzywuzzy==0.17.0
 PyYAML==5.2.0
 tox==3.14.0
-pre-commit==2.1.1
+pre-commit==1.18.3

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,13 +1,85 @@
 """
 Unit tests for Serializers
 """
+import csv
 import unittest
+from os import remove
+from os.path import isfile
+
+from rac_aspace import serializers
 
 
 class TestSerializers(unittest.TestCase):
+    """Tests CSV and TSV serializers."""
 
-    def test_serialization(self):
-        pass
+    def setUp(self):
+        """Sets data attributes to be serialized."""
+        self.long_data = [{"column1": "value", "column2": "value"},
+                          {"column1": "another value", "column2": "blah"}]
+        self.short_data = [{"column1": "value", "column2": "value"}]
+
+    def test_csv_serializer(self):
+        """Tests CSVWriter.
+
+        Ensures that the correct filename is created, and that the expected
+        number of rows are written to the file.
+        """
+        expected_filepath = "spreadsheet.csv"
+        for filepath in ["spreadsheet.csv", "spreadsheet",
+                         "spreadsheet.tsv", "spreadsheet.jpeg"]:
+            for data in [self.long_data, self.short_data]:
+                serializer = serializers.CSVWriter(filepath)
+                serializer.write_data(data)
+                with open(expected_filepath, "r") as out_file:
+                    reader = csv.reader(
+                        out_file, delimiter=serializer.delimiter)
+                    out_data = [r for r in reader]
+                    self.assertEqual(out_data[0], ["column1", "column2"])
+                    self.assertEqual(len(out_data), len(data) + 1)
+                remove(expected_filepath)
+
+    def test_tsv_serializer(self):
+        """Tests TSVWriter.
+
+        Ensures that the correct filename is created, and that the expected
+        number of rows are written to the file.
+        """
+        expected_filepath = "spreadsheet.tsv"
+        for filepath in ["spreadsheet.tsv", "spreadsheet",
+                         "spreadsheet.csv", "spreadsheet.jpeg"]:
+            for data in [self.long_data, self.short_data]:
+                serializer = serializers.TSVWriter(filepath)
+                serializer.write_data(data)
+                with open(expected_filepath, "r") as out_file:
+                    reader = csv.reader(
+                        out_file, delimiter=serializer.delimiter)
+                    out_data = [r for r in reader]
+                    self.assertEqual(out_data[0], ["column1", "column2"])
+                    self.assertEqual(len(out_data), len(data) + 1)
+                remove(expected_filepath)
+
+    def test_filemodes(self):
+        """Tests different filemodes.
+
+        Ensures that write modes create a file, and that read-only modes throw
+        a meaningful exception.
+        """
+        for filemode in ["a", "a+", "w", "w+"]:
+            for serializer in [serializers.CSVWriter, serializers.TSVWriter]:
+                expected_filepath = "test.{}".format(serializer.extension)
+                s = serializer("test", filemode=filemode)
+                s.write_data(self.short_data)
+                self.assertTrue(isfile(expected_filepath))
+                remove(expected_filepath)
+        for filemode in ["r", "r+"]:
+            for serializer in [serializers.CSVWriter, serializers.TSVWriter]:
+                with self.assertRaises(TypeError):
+                    serializer("test", filemode=filemode)
+
+    def tearDown(self):
+        for filename in ["spreadsheet.csv", "spreadsheet.tsv"]:
+            if isfile(filename):
+                remove(filename)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Changes
Adds unit tests for serializers:
- Ensures that data is written to CSV and TSV files correctly (`test_csv_serializer` and `test_tsv_serializer`)
  - All filenames have the correct extension
  - The expected headers were written to the spreadsheet
 - The correct number of rows were written to the spreadsheet
- Ensures that different filemodes are handled correctly
  - Write file modes should result in the creation of a file
  - Read-only file modes should result in a TypeError exception being thrown 

Makes a number of changes to serializers:
- raising an exception if the filemode is read-only.
- always appends the correct extension to the filename, either replacing the incorrect extension or adding it if doesn't exist.
- adds an `extension` property to CSVWriter and TSVWriter.
- updating docstrings to conform with Google format. fixes #55

## Questions
- Is the filename handling too overboard? Do we need this?
- It would be possible to refactor `test_csv_serializer` and `test_tsv_serializer` into a single test function by adding another for loop. How do folks feel about this - the tradeoff is legibility over concision.

fixes #38